### PR TITLE
Add support for multiple stations as required argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the station at Logan Airport in Boston.
 You can then run `nws_exporter` for this station as demonstrated below.
 
 ```text
-./nws_exporter --station KBOS
+./nws_exporterg KBOS
 ```
 
 ### Run
@@ -77,7 +77,7 @@ Make sure to edit the unit file to use a station near you that you picked in the
 ```text
 sudo cp target/release/nws_exporter /usr/local/bin/nws_exporter
 sudo cp ext/nws_exporter.service /etc/systemd/system/nws_exporter.service
-sudo sed -i 's/--station KBOS/--station YOUR_STATION/' /etc/systemd/system/nws_exporter.service
+sudo sed -i 's/KBOS/YOUR_STATION/' /etc/systemd/system/nws_exporter.service
 sudo systemctl daemon-reload
 sudo systemctl enable nws_exporter.service
 sudo systemctl start nws_exporter.serivce

--- a/ext/nws_exporter.service
+++ b/ext/nws_exporter.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=nobody
-ExecStart=/usr/local/bin/nws_exporter --station KBOS --log-level debug
+ExecStart=/usr/local/bin/nws_exporter --log-level=debug KBOS
 
 CapabilityBoundingSet=
 NoNewPrivileges=yes

--- a/src/nws_exporter/lib.rs
+++ b/src/nws_exporter/lib.rs
@@ -77,7 +77,7 @@
 //! You can then run `nws_exporter` for this station as demonstrated below.
 //!
 //! ```text
-//! ./nws_exporter --station KBOS
+//! ./nws_exporter KBOS
 //! ```
 //!
 //! ### Run
@@ -89,7 +89,7 @@
 //! ```text
 //! sudo cp target/release/nws_exporter /usr/local/bin/nws_exporter
 //! sudo cp ext/nws_exporter.service /etc/systemd/system/nws_exporter.service
-//! sudo sed -i 's/--station KBOS/--station YOUR_STATION/' /etc/systemd/system/nws_exporter.service
+//! sudo sed -i 's/KBOS/YOUR_STATION/' /etc/systemd/system/nws_exporter.service
 //! sudo systemctl daemon-reload
 //! sudo systemctl enable nws_exporter.service
 //! sudo systemctl start nws_exporter.serivce


### PR DESCRIPTION
Turn `--station` into a positional argument that supports multiple
values to allow fetching forecasts for multiple NWS stations with
the same exporter instance.

Fixes #5